### PR TITLE
Use endorsed version of meta package

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.15.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR fixes the following static analysis issue:

```
The import of 'package:meta/meta.dart' is unnecessary because all of the used elements
are also provided by the import of 'package:flutter/foundation.dart'.
```