### PR TITLE
Add constraint assertion to prevent unbounded dimensions in NavigatorResizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## X.X.X
+
+- `NavigatorResizable` now asserts when provided with unbounded width or height constraints.
+
+### Breaking change in `NavigatorResizable`
+
+`NavigatorResizable` requires bounded constraints on both axes. If its parent passes unbounded constraints (e.g., from `Column`, `Row`), an assertion is thrown in debug mode. This helps catch cases where routes inside the underlying `Navigator` might otherwise receive infinite dimensions, which often surface when route content uses `double.infinity` for width/height to expand and fill the available space.
+
 ## 2.0.0
 
 - Updated minimum supported Flutter SDK to `3.29.0`.

--- a/example/lib/minimal_declarative_example.dart
+++ b/example/lib/minimal_declarative_example.dart
@@ -79,23 +79,25 @@ class _ExampleHomeState extends State<ExampleHome> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              const Spacer(),
-              Material(
-                elevation: 2,
-                color: Colors.white,
-                clipBehavior: Clip.antiAlias,
-                borderRadius: BorderRadius.circular(8),
-                // IMPORTANT: Wrap the Navigator in a NavigatorResizable.
-                child: NavigatorResizable(
-                  child: Navigator(
-                    pages: _pages,
-                    onDidRemovePage: (removedPage) {
-                      _pages.remove(removedPage);
-                    },
+              Expanded(
+                child: Center(
+                  child: Material(
+                    elevation: 2,
+                    color: Colors.white,
+                    clipBehavior: Clip.antiAlias,
+                    borderRadius: BorderRadius.circular(8),
+                    // IMPORTANT: Wrap the Navigator in a NavigatorResizable.
+                    child: NavigatorResizable(
+                      child: Navigator(
+                        pages: _pages,
+                        onDidRemovePage: (removedPage) {
+                          _pages.remove(removedPage);
+                        },
+                      ),
+                    ),
                   ),
                 ),
               ),
-              const Spacer(),
               SizedBox(
                 width: double.infinity,
                 child: Wrap(

--- a/lib/src/navigator_resizable.dart
+++ b/lib/src/navigator_resizable.dart
@@ -311,6 +311,19 @@ class _RenderNavigatorResizable extends RenderAligningShiftedBox {
       'The given constraints were: $constraints which was given by '
       'the parent: ${parent.runtimeType}',
     );
+    assert(
+      constraints.hasBoundedHeight && constraints.hasBoundedWidth,
+      'The NavigatorResizable widget was given unbounded constraints. '
+      'This is not allowed because otherwise the routes within the underlying '
+      'Navigator would not know their valid maximum size. This becomes '
+      'especially problematic when a route specifies double.infinity for width '
+      'or height to expand to the available space, which causes a layout error '
+      'since the parent Navigator does not provide finite bounds.\n'
+      'Make sure that NavigatorResizable is not wrapped in a widget that '
+      'passes unbounded constraints to its children, such as Column or Row. '
+      'The given constraints were:\n'
+      '$constraints (from parent: ${parent.runtimeType}).',
+    );
 
     // Pass the parent constraints directly to the child Navigator,
     // allowing it to overflow this render box if necessary.


### PR DESCRIPTION
## Purpose

This change improves the developer experience by catching a common layout issue early in development. When `NavigatorResizable` receives unbounded constraints from parent widgets like `Column` or `Row`, routes within the underlying `Navigator` may receive infinite dimensions, leading to layout errors that are often difficult to debug.

## What Changed

`NavigatorResizable` now asserts in debug mode when provided with unbounded width or height constraints. The assertion provides a clear error message explaining why unbounded constraints are problematic and suggests wrapping with widgets that provide bounded constraints.

