### PR TITLE
Fix: NavigatorResizable size doesn't update when the current route is changed via Navigator.replace

### DIFF
--- a/lib/src/navigator_event_observer.dart
+++ b/lib/src/navigator_event_observer.dart
@@ -357,7 +357,7 @@ class NavigatorEventObserverState extends State<NavigatorEventObserver>
         ? route.transitionDuration
         : Duration.zero;
 
-    if (duration == Duration.zero || route is! TransitionRoute<dynamic>) {
+    if (duration == Duration.zero) {
       _lastSettledRoute = route;
       _notifyListeners((it) => it.didEndTransition(route));
       return;

--- a/lib/src/navigator_event_observer.dart
+++ b/lib/src/navigator_event_observer.dart
@@ -124,14 +124,11 @@ class NavigatorEventObserver extends StatefulWidget {
 }
 
 /// The state of [NavigatorEventObserver].
-class NavigatorEventObserverState extends State<NavigatorEventObserver>
-    with TickerProviderStateMixin {
+class NavigatorEventObserverState extends State<NavigatorEventObserver> {
   final Set<NavigatorEventListener> _listeners = {};
   final Map<Route<dynamic>, Route<dynamic>?> _nextRouteOf = {};
   final Map<Route<dynamic>, Route<dynamic>?> _previousRouteOf = {};
   NavigatorState? _navigator;
-  AnimationController? _replaceAnimationController;
-
   @visibleForTesting
   Route<dynamic>? get lastSettledRoute => _lastSettledRoute;
   Route<dynamic>? _lastSettledRoute;
@@ -187,8 +184,6 @@ class NavigatorEventObserverState extends State<NavigatorEventObserver>
     _listeners.clear();
     _nextRouteOf.clear();
     _previousRouteOf.clear();
-    _replaceAnimationController?.dispose();
-    _replaceAnimationController = null;
     _navigator?.userGestureInProgressNotifier
         .removeListener(_didUserGestureInProgressChange);
     _navigator = null;
@@ -345,43 +340,9 @@ class NavigatorEventObserverState extends State<NavigatorEventObserver>
 
   void _didReplace(Route<dynamic> route, Route<dynamic>? oldRoute) {
     _notifyListeners((it) => it.didReplace(route, oldRoute));
-
-    // Only animate if the replaced route was the current (settled) route.
     if (oldRoute != _lastSettledRoute) return;
-
-    // Cancel any in-progress replace animation.
-    _replaceAnimationController?.dispose();
-    _replaceAnimationController = null;
-
-    final duration = route is TransitionRoute<dynamic>
-        ? route.transitionDuration
-        : Duration.zero;
-
-    if (duration == Duration.zero) {
-      _lastSettledRoute = route;
-      _notifyListeners((it) => it.didEndTransition(route));
-      return;
-    }
-
-    final controller = AnimationController(vsync: this, duration: duration);
-    _replaceAnimationController = controller;
-
-    // Start the animation before notifying listeners so that
-    // the animation status is AnimationStatus.forward.
-    controller.forward().then((_) {
-      if (_replaceAnimationController == controller) {
-        _replaceAnimationController = null;
-        if (route.isCurrent) {
-          _lastSettledRoute = route;
-          _notifyListeners((it) => it.didEndTransition(route));
-        }
-        controller.dispose();
-      }
-    });
-
-    _notifyListeners((it) {
-      it.didStartTransition(route, controller);
-    });
+    _lastSettledRoute = route;
+    _notifyListeners((it) => it.didEndTransition(route));
   }
 
   void _didUserGestureInProgressChange() {

--- a/test/navigator_event_observer_test.dart
+++ b/test/navigator_event_observer_test.dart
@@ -1287,8 +1287,7 @@ void main() {
       ]);
       verifyNoMoreInteractions(env.listener);
 
-      final capturedAnimation =
-          results[2].captured.single as Animation<double>;
+      final capturedAnimation = results[2].captured.single as Animation<double>;
       expect(capturedAnimation.status, AnimationStatus.forward);
 
       startTrackingTransitionProgress(capturedAnimation);

--- a/test/navigator_event_observer_test.dart
+++ b/test/navigator_event_observer_test.dart
@@ -503,57 +503,6 @@ void main() {
         navigator.replace(oldRoute: routeB, newRoute: newRoute);
         await tester.pump();
 
-        final results = verifyInOrder([
-          env.listener.didInstall(argThat(isRoute(name: 'c'))),
-          env.listener.didReplace(
-            argThat(isRoute(name: 'c')),
-            argThat(isRoute(name: 'b')),
-          ),
-          env.listener.didStartTransition(
-            argThat(isRoute(name: 'c')),
-            captureAny,
-          ),
-        ]);
-        verifyNever(env.listener.didPush(any));
-
-        final capturedAnimation =
-            results[2].captured.single as Animation<double>;
-        expect(capturedAnimation.status, AnimationStatus.forward);
-
-        startTrackingTransitionProgress(capturedAnimation);
-        await tester.pumpAndSettle();
-
-        expect(find.text('Page:c'), findsOneWidget);
-        expect(transitionProgressHistory, isMonotonicallyIncreasing);
-        expect(env.getObserver().lastSettledRoute, isRoute(name: 'c'));
-        verify(env.listener.didEndTransition(
-          argThat(isRoute(name: 'c')),
-        )).called(1);
-      },
-    );
-
-    testWidgets(
-      'When replacing a route with Navigator.replace without animation',
-      (tester) async {
-        final env = boilerplate(transitionDuration: Duration.zero);
-        await tester.pumpWidget(env.testWidget);
-        // Push route 'b' on top of 'a' and capture the route.
-        unawaited(env.navigatorKey.currentState!.pushNamed('b'));
-        await tester.pumpAndSettle();
-        expect(find.text('Page:b'), findsOneWidget);
-        final routeB = env.getObserver().lastSettledRoute!;
-        expect(routeB.settings.name, 'b');
-
-        reset(env.listener);
-        final navigator = env.navigatorKey.currentState!;
-        final newRoute = _TestMaterialPageRoute(
-          settings: const RouteSettings(name: 'c'),
-          transitionDuration: Duration.zero,
-          builder: (_) => const _TestScaffold(title: 'Page:c'),
-        );
-        navigator.replace(oldRoute: routeB, newRoute: newRoute);
-        await tester.pump();
-
         verifyInOrder([
           env.listener.didInstall(argThat(isRoute(name: 'c'))),
           env.listener.didReplace(

--- a/test/navigator_event_observer_test.dart
+++ b/test/navigator_event_observer_test.dart
@@ -480,6 +480,100 @@ void main() {
     });
 
     testWidgets(
+      'When replacing a route with Navigator.replace',
+      (tester) async {
+        final env = boilerplate();
+        await tester.pumpWidget(env.testWidget);
+        // Push route 'b' on top of 'a' and capture the route object.
+        unawaited(env.navigatorKey.currentState!.pushNamed('b'));
+        // Capture routeB via the lastSettledRoute after settling.
+        await tester.pumpAndSettle();
+        expect(find.text('Page:b'), findsOneWidget);
+        final routeB = env.getObserver().lastSettledRoute!;
+        expect(routeB.settings.name, 'b');
+
+        reset(env.listener);
+        // Use Navigator.replace to swap 'b' with 'c'.
+        final navigator = env.navigatorKey.currentState!;
+        final newRoute = _TestMaterialPageRoute(
+          settings: const RouteSettings(name: 'c'),
+          transitionDuration: const Duration(milliseconds: 300),
+          builder: (_) => const _TestScaffold(title: 'Page:c'),
+        );
+        navigator.replace(oldRoute: routeB, newRoute: newRoute);
+        await tester.pump();
+
+        final results = verifyInOrder([
+          env.listener.didInstall(argThat(isRoute(name: 'c'))),
+          env.listener.didReplace(
+            argThat(isRoute(name: 'c')),
+            argThat(isRoute(name: 'b')),
+          ),
+          env.listener.didStartTransition(
+            argThat(isRoute(name: 'c')),
+            captureAny,
+          ),
+        ]);
+        verifyNever(env.listener.didPush(any));
+
+        final capturedAnimation =
+            results[2].captured.single as Animation<double>;
+        expect(capturedAnimation.status, AnimationStatus.forward);
+
+        startTrackingTransitionProgress(capturedAnimation);
+        await tester.pumpAndSettle();
+
+        expect(find.text('Page:c'), findsOneWidget);
+        expect(transitionProgressHistory, isMonotonicallyIncreasing);
+        expect(env.getObserver().lastSettledRoute, isRoute(name: 'c'));
+        verify(env.listener.didEndTransition(
+          argThat(isRoute(name: 'c')),
+        )).called(1);
+      },
+    );
+
+    testWidgets(
+      'When replacing a route with Navigator.replace without animation',
+      (tester) async {
+        final env = boilerplate(transitionDuration: Duration.zero);
+        await tester.pumpWidget(env.testWidget);
+        // Push route 'b' on top of 'a' and capture the route.
+        unawaited(env.navigatorKey.currentState!.pushNamed('b'));
+        await tester.pumpAndSettle();
+        expect(find.text('Page:b'), findsOneWidget);
+        final routeB = env.getObserver().lastSettledRoute!;
+        expect(routeB.settings.name, 'b');
+
+        reset(env.listener);
+        final navigator = env.navigatorKey.currentState!;
+        final newRoute = _TestMaterialPageRoute(
+          settings: const RouteSettings(name: 'c'),
+          transitionDuration: Duration.zero,
+          builder: (_) => const _TestScaffold(title: 'Page:c'),
+        );
+        navigator.replace(oldRoute: routeB, newRoute: newRoute);
+        await tester.pump();
+
+        verifyInOrder([
+          env.listener.didInstall(argThat(isRoute(name: 'c'))),
+          env.listener.didReplace(
+            argThat(isRoute(name: 'c')),
+            argThat(isRoute(name: 'b')),
+          ),
+          env.listener.didEndTransition(
+            argThat(isRoute(name: 'c')),
+          ),
+        ]);
+        verifyNever(env.listener.didPush(any));
+        verifyNever(env.listener.didStartTransition(any, any));
+
+        await tester.pumpAndSettle();
+        expect(find.text('Page:c'), findsOneWidget);
+        expect(env.getObserver().lastSettledRoute, isRoute(name: 'c'));
+      },
+    );
+
+    testWidgets(
       'When pushing to a sibling route then reverting mid-transition',
       (tester) async {
         final env = boilerplate(

--- a/test/navigator_resizable_test.dart
+++ b/test/navigator_resizable_test.dart
@@ -254,28 +254,7 @@ void main() {
         builder: (_) => const _TestRouteWidget(initialSize: Size(150, 250)),
       );
       navigator.replace(oldRoute: routeB, newRoute: newRoute);
-      expect(env.getBox(tester).size, const Size(200, 300));
-
-      Size interpolatedSize(double progress) {
-        return Size.lerp(
-          const Size(200, 300),
-          const Size(150, 250),
-          Curves.easeInOut.transform(progress),
-        )!;
-      }
-
-      await tester.pump(Duration.zero);
-
-      await tester.pump(const Duration(milliseconds: 75));
-      expect(env.getBox(tester).size, interpolatedSize(0.25));
-
-      await tester.pump(const Duration(milliseconds: 75));
-      expect(env.getBox(tester).size, interpolatedSize(0.5));
-
-      await tester.pump(const Duration(milliseconds: 75));
-      expect(env.getBox(tester).size, interpolatedSize(0.75));
-
-      await tester.pumpAndSettle();
+      await tester.pump();
       expect(env.getBox(tester).size, const Size(150, 250));
     });
 

--- a/test/navigator_resizable_test.dart
+++ b/test/navigator_resizable_test.dart
@@ -239,6 +239,46 @@ void main() {
       expect(env.getBox(tester).size, const Size(150, 250));
     });
 
+    testWidgets('When replacing a route with Navigator.replace',
+        (tester) async {
+      final env = boilerplate();
+      await tester.pumpWidget(env.testWidget);
+      unawaited(env.navigatorKey.currentState!.pushNamed('b'));
+      await tester.pumpAndSettle();
+      expect(env.getBox(tester).size, const Size(200, 300));
+
+      final routeB = env.navigatorKey.currentState!.currentRoute;
+      final navigator = env.navigatorKey.currentState!;
+      final newRoute = ResizableMaterialPageRoute(
+        settings: const RouteSettings(name: 'c'),
+        builder: (_) => const _TestRouteWidget(initialSize: Size(150, 250)),
+      );
+      navigator.replace(oldRoute: routeB, newRoute: newRoute);
+      expect(env.getBox(tester).size, const Size(200, 300));
+
+      Size interpolatedSize(double progress) {
+        return Size.lerp(
+          const Size(200, 300),
+          const Size(150, 250),
+          Curves.easeInOut.transform(progress),
+        )!;
+      }
+
+      await tester.pump(Duration.zero);
+
+      await tester.pump(const Duration(milliseconds: 75));
+      expect(env.getBox(tester).size, interpolatedSize(0.25));
+
+      await tester.pump(const Duration(milliseconds: 75));
+      expect(env.getBox(tester).size, interpolatedSize(0.5));
+
+      await tester.pump(const Duration(milliseconds: 75));
+      expect(env.getBox(tester).size, interpolatedSize(0.75));
+
+      await tester.pumpAndSettle();
+      expect(env.getBox(tester).size, const Size(150, 250));
+    });
+
     testWidgets('When iOS swipe back gesture is performed', (tester) async {
       final env = boilerplate();
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;

--- a/test/navigator_resizable_test.dart
+++ b/test/navigator_resizable_test.dart
@@ -250,12 +250,23 @@ void main() {
 
       final routeB = env.navigatorKey.currentState!.currentRoute;
       final navigator = env.navigatorKey.currentState!;
-      final newRoute = ResizableMaterialPageRoute(
+      final newRoute = ResizablePageRouteBuilder(
         settings: const RouteSettings(name: 'c'),
-        builder: (_) => const _TestRouteWidget(initialSize: Size(150, 250)),
+        transitionDuration: const Duration(milliseconds: 300),
+        pageBuilder: (_, __, ___) =>
+            const _TestRouteWidget(initialSize: Size(150, 250)),
+        transitionsBuilder: _testTransitionsBuilder,
       );
       navigator.replace(oldRoute: routeB, newRoute: newRoute);
+
       await tester.pump();
+      expect(
+        env.getBox(tester).size,
+        const Size(150, 250),
+        reason: 'The size should immediately change to the new route '
+            'without animation.',
+      );
+      await tester.pumpAndSettle();
       expect(env.getBox(tester).size, const Size(150, 250));
     });
   });


### PR DESCRIPTION
## Context

Fixes an issue where `Navigator.replace()` does not trigger `NavigatorResizable` size updates. The `_didReplace` method in `NavigatorEventObserverState` only forwards the raw `didReplace` event but does not dispatch `didEndTransition`, so `NavigatorSizeNotifier` dispatcher never update during a replace operation.

## Solution

When `_didReplace` is called and the replaced route was the current settled route, immediately update `_lastSettledRoute` and dispatch `didEndTransition`. No `didStartTransition` is fired because `Navigator.replace()` swaps routes instantly without a real transition animation.
