### PR TITLE
Run code quality checks against only the latest supported SDK in CI

### DIFF
--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -50,11 +50,6 @@ jobs:
     needs: setup
     if: ${{ needs.setup.outputs.flutter-file-changed == 'true' }}
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        flutter-version:
-          - ${{ needs.setup.outputs.flutter-lower-bound }}
-          - ${{ needs.setup.outputs.flutter-upper-bound }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,7 +57,7 @@ jobs:
       - name: Setup Flutter
         uses: ./.github/actions/setup_flutter
         with:
-          version: ${{ matrix.flutter-version }}
+          version: ${{ needs.setup.outputs.flutter-upper-bound }}
 
       - name: Format
         run: dart format . -o none --set-exit-if-changed

--- a/lib/navigator_resizable.dart
+++ b/lib/navigator_resizable.dart
@@ -1,4 +1,3 @@
-// test.
 export 'src/navigator_event_observer.dart';
 export 'src/navigator_resizable.dart';
 export 'src/resizable_navigator_routes.dart';

--- a/lib/navigator_resizable.dart
+++ b/lib/navigator_resizable.dart
@@ -1,3 +1,4 @@
+// test.
 export 'src/navigator_event_observer.dart';
 export 'src/navigator_resizable.dart';
 export 'src/resizable_navigator_routes.dart';


### PR DESCRIPTION
To prevent the workflow from failing due to differing formatter outputs between the latest and minimum supported SDK versions. The testing job still runs against both SDKs, so any compile errors with the minimum SDK will be caught there.