### PR TITLE
Fix jaggy route pop animation with predictive back gesture on Android

### DIFF
--- a/example/lib/minimal_imperative_example.dart
+++ b/example/lib/minimal_imperative_example.dart
@@ -15,8 +15,8 @@ class ExampleApp extends StatelessWidget {
         body: Align(
           // Try changing the alignment for fun!
           alignment: Alignment.center,
-          child: ColoredBox(
-            color: Colors.purple,
+          child: Material(
+            elevation: 4,
             // STEP1: Wrap the navigator with NavigatorResizable.
             child: NavigatorResizable(
               child: Navigator(

--- a/lib/src/navigator_resizable.dart
+++ b/lib/src/navigator_resizable.dart
@@ -112,8 +112,8 @@ import 'resizable_navigator_routes.dart';
 /// );
 /// ```
 /// You can use any standard navigation methods, such as [Navigator.push],
-/// [Navigator.pop], [named routes](https://api.flutter.dev/flutter/widgets/Navigator-class.html#:~:text=Using%20named%20navigator%20routes),
-/// and the [Pages API](https://api.flutter.dev/flutter/widgets/Navigator-class.html#:~:text=the%20current%20page.-,Using%20the%20Pages%20API,-The%20Navigator%20will),
+/// [Navigator.pop], [named routes][1],
+/// and the [Pages API][2],
 /// with [NavigatorResizable] as you would with a regular [Navigator]:
 ///
 /// ```dart
@@ -131,8 +131,11 @@ import 'resizable_navigator_routes.dart';
 /// );
 /// ```
 ///
-/// For more practical examples, refer to the
-/// [/example](https://github.com/fujidaiti/navigator_resizable/tree/main/example/lib) directory.
+/// For more practical examples, refer to the [/example][3] directory.
+///
+/// [1]: https://api.flutter.dev/flutter/widgets/Navigator-class.html#:~:text=Using%20named%20navigator%20routes
+/// [2]: https://api.flutter.dev/flutter/widgets/Navigator-class.html#:~:text=the%20current%20page.-,Using%20the%20Pages%20API,-The%20Navigator%20will
+/// [3]: https://github.com/fujidaiti/navigator_resizable/tree/main/example/lib
 class NavigatorResizable extends StatefulWidget {
   /// Creates a thin wrapper around [Navigator] that **visually** resizes
   /// the [child] navigator to match the size of the content displayed

--- a/lib/src/navigator_size_notifier.dart
+++ b/lib/src/navigator_size_notifier.dart
@@ -107,7 +107,7 @@ class NavigatorSizeNotifier extends ChangeNotifier
     Route<dynamic> targetRoute,
     Animation<double> animation,
   ) {
-    assert(animation.status == AnimationStatus.forward);
+    assert(animation.isForwardOrCompleted);
     final initialSize = _lastReportedValidValue!;
     _updateInterpolation(
       _LazySizeTween(
@@ -121,7 +121,7 @@ class NavigatorSizeNotifier extends ChangeNotifier
     Route<dynamic> targetRoute,
     Animation<double> animation,
   ) {
-    assert(animation.status == AnimationStatus.forward);
+    assert(animation.isForwardOrCompleted);
     final initialSize = _lastReportedValidValue!;
     _updateInterpolation(
       _LazySizeTween(
@@ -135,7 +135,7 @@ class NavigatorSizeNotifier extends ChangeNotifier
     Route<dynamic> targetRoute,
     Animation<double> animation,
   ) {
-    assert(animation.status == AnimationStatus.reverse);
+    assert(!animation.isForwardOrCompleted);
     final initialSize = _lastReportedValidValue!;
     if (animation.value == 1) {
       _updateInterpolation(

--- a/lib/src/resizable_navigator_routes.dart
+++ b/lib/src/resizable_navigator_routes.dart
@@ -193,7 +193,7 @@ class _AnimationLessAndroidBackGestureHandlerState
 
   @override
   bool handleStartBackGesture(PredictiveBackEvent backEvent) {
-    return !backEvent.isButtonEvent && _route.isCurrent;
+    return !backEvent.isButtonEvent && _route.isCurrent && !_route.isFirst;
   }
 
   @override

--- a/lib/src/resizable_navigator_routes.dart
+++ b/lib/src/resizable_navigator_routes.dart
@@ -1,30 +1,88 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'navigator_event_observer.dart';
 import 'navigator_resizable.dart';
 
-/// A specialized [MaterialPageRoute] compatible with [NavigatorResizable].
-///
-/// For a detailed explanation of each property, see [MaterialPageRoute].
-@optionalTypeArgs
-class ResizableMaterialPageRoute<T> extends MaterialPageRoute<T>
-    with ObservableRouteMixin<T> {
-  /// Creates a [MaterialPageRoute] compatible with [NavigatorResizable].
-  ResizableMaterialPageRoute({
-    required super.builder,
+abstract class _BaseResizableMaterialPageRoute<T> extends PageRoute<T>
+    with ObservableRouteMixin<T>, MaterialRouteTransitionMixin<T> {
+  _BaseResizableMaterialPageRoute({
     super.settings,
     super.requestFocus,
-    super.maintainState,
     super.fullscreenDialog,
     super.allowSnapshotting,
     super.barrierDismissible,
   });
 
+  Widget _buildContentInternal(BuildContext context);
+
   @override
   Widget buildContent(BuildContext context) {
-    return ResizableNavigatorRouteContentBoundary(
-      child: builder(context),
+    final result = ResizableNavigatorRouteContentBoundary(
+      child: _buildContentInternal(context),
     );
+    return switch (Theme.of(context).platform) {
+      TargetPlatform.android => _AnimationLessAndroidBackGestureHandler(
+        child: result,
+      ),
+      _ => result,
+    };
+  }
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return switch (Theme.of(context).platform) {
+      // PredictiveBackFullscreenPageTransitionsBuilder is incompatible with
+      // NavigatorResizable's size transition, so we use the older
+      // ZoomPageTransitionsBuilder for Android instead.
+      TargetPlatform.android =>
+        const ZoomPageTransitionsBuilder().buildTransitions(
+          this,
+          context,
+          animation,
+          secondaryAnimation,
+          child,
+        ),
+      _ => super.buildTransitions(
+        context,
+        animation,
+        secondaryAnimation,
+        child,
+      ),
+    };
+  }
+}
+
+/// A specialized [MaterialPageRoute] compatible with [NavigatorResizable].
+///
+/// For a detailed explanation of each property, see [MaterialPageRoute].
+@optionalTypeArgs
+class ResizableMaterialPageRoute<T> extends _BaseResizableMaterialPageRoute<T> {
+  /// Creates a [MaterialPageRoute] compatible with [NavigatorResizable].
+  ResizableMaterialPageRoute({
+    required this.builder,
+    super.settings,
+    super.requestFocus,
+    super.fullscreenDialog,
+    super.allowSnapshotting,
+    super.barrierDismissible,
+    this.maintainState = true,
+  });
+
+  @override
+  final bool maintainState;
+
+  /// Builds the primary contents of the route.
+  final WidgetBuilder builder;
+
+  @override
+  Widget _buildContentInternal(BuildContext context) {
+    return builder(context);
   }
 }
 
@@ -55,8 +113,8 @@ class ResizableMaterialPage<T> extends MaterialPage<T> {
       );
 }
 
-class _PageBasedResizableMaterialPageRoute<T> extends PageRoute<T>
-    with ObservableRouteMixin<T>, MaterialRouteTransitionMixin<T> {
+class _PageBasedResizableMaterialPageRoute<T>
+    extends _BaseResizableMaterialPageRoute<T> {
   _PageBasedResizableMaterialPageRoute({
     required ResizableMaterialPage<T> page,
     required super.allowSnapshotting,
@@ -75,10 +133,88 @@ class _PageBasedResizableMaterialPageRoute<T> extends PageRoute<T>
   String get debugLabel => '${super.debugLabel}(${page.name})';
 
   @override
-  Widget buildContent(BuildContext context) {
-    return ResizableNavigatorRouteContentBoundary(
-      child: page.child,
-    );
+  Widget _buildContentInternal(BuildContext context) {
+    return page.child;
+  }
+}
+
+/// Enables Android's predictive back gesture to pop routes within the
+/// nested [Navigator], without modifying route transition progress during
+/// the gesture.
+///
+/// This is a workaround for the issue where [TransitionRoute.animation]
+/// jumps from a mid-transition value to 1.0 when the back gesture is committed,
+/// causing an abrupt pop-transition animation.
+///
+/// The root cause is that [TransitionRoute.handleUpdateBackGestureProgress]
+/// updates the [TransitionRoute.controller]'s value as the gesture progresses,
+/// but [TransitionRoute.handleCommitBackGesture] triggers the transition
+/// animation via [AnimationController.reverse] with 1.0 as the starting point,
+/// regardless of the current [TransitionRoute.controller]'s value.
+///
+/// The default back gesture handler behaves this way, but is incompatible with
+/// [NavigatorResizable]'s size transition. This handler therefore suppresses
+/// gesture-driven transition progress while still allowing the gesture to
+/// commit a route pop.
+class _AnimationLessAndroidBackGestureHandler extends StatefulWidget {
+  const _AnimationLessAndroidBackGestureHandler({
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  State<_AnimationLessAndroidBackGestureHandler> createState() =>
+      _AnimationLessAndroidBackGestureHandlerState();
+}
+
+class _AnimationLessAndroidBackGestureHandlerState
+    extends State<_AnimationLessAndroidBackGestureHandler>
+    with WidgetsBindingObserver {
+  late ModalRoute<dynamic> _route;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _route = ModalRoute.of(context)!;
+  }
+
+  @override
+  bool handleStartBackGesture(PredictiveBackEvent backEvent) {
+    return !backEvent.isButtonEvent && _route.isCurrent;
+  }
+
+  @override
+  void handleCancelBackGesture() {
+    _handleEndBackGesture(isCommitted: false);
+  }
+
+  @override
+  void handleCommitBackGesture() {
+    _handleEndBackGesture(isCommitted: true);
+  }
+
+  void _handleEndBackGesture({required bool isCommitted}) {
+    if (isCommitted && _route.isCurrent) {
+      _route.navigator?.pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
   }
 }
 

--- a/lib/src/resizable_navigator_routes.dart
+++ b/lib/src/resizable_navigator_routes.dart
@@ -39,9 +39,9 @@ abstract class _BaseResizableMaterialPageRoute<T> extends PageRoute<T>
     return switch (Theme.of(context).platform) {
       // PredictiveBackFullscreenPageTransitionsBuilder is incompatible with
       // NavigatorResizable's size transition, so we use the older
-      // ZoomPageTransitionsBuilder for Android instead.
+      // FadeForwardsPageTransitionsBuilder for Android instead.
       TargetPlatform.android =>
-        const ZoomPageTransitionsBuilder().buildTransitions(
+        const FadeForwardsPageTransitionsBuilder().buildTransitions(
           this,
           context,
           animation,

--- a/test/navigator_resizable_test.dart
+++ b/test/navigator_resizable_test.dart
@@ -5,6 +5,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:navigator_resizable/src/navigator_resizable.dart';
 import 'package:navigator_resizable/src/resizable_navigator_routes.dart';
 
+import 'src/matchers.dart';
+import 'src/widget_tester_x.dart';
+
 void main() {
   group('Size transition test with imperative navigator API', () {
     ({
@@ -400,6 +403,175 @@ void main() {
       },
     );
   });
+
+  group(
+    'Android predictive back gesture test with '
+    'imperative navigator API and ResizableMaterialPageRoute',
+    () {
+      ({
+        GlobalKey<NavigatorState> navigatorKey,
+        Widget testWidget,
+      })
+      boilerplate() {
+        final navigatorKey = GlobalKey<NavigatorState>();
+        final navigatorResizableKey = UniqueKey();
+        final routes = {
+          'a': () => const _TestRouteWidget(initialSize: Size(100, 200)),
+          'b': () => const _TestRouteWidget(initialSize: Size(200, 300)),
+        };
+        final testWidget = MaterialApp(
+          home: Align(
+            alignment: Alignment.center,
+            child: NavigatorResizable(
+              key: navigatorResizableKey,
+              child: Navigator(
+                key: navigatorKey,
+                initialRoute: 'a',
+                onGenerateRoute: (settings) {
+                  return ResizableMaterialPageRoute(
+                    settings: settings,
+                    builder: (_) => routes[settings.name]!(),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        return (
+          navigatorKey: navigatorKey,
+          testWidget: testWidget,
+        );
+      }
+
+      testWidgets(
+        'When back gesture is performed',
+        variant: TargetPlatformVariant.only(TargetPlatform.android),
+        (tester) async {
+          final env = boilerplate();
+          await tester.pumpWidget(env.testWidget);
+
+          unawaited(env.navigatorKey.currentState!.pushNamed('b'));
+          await tester.pumpAndSettle();
+
+          await tester.startAndroidBackGesture(
+            touchOffset: [5.0, 300.0],
+          );
+          await tester.pump();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+          );
+
+          await tester.updateAndroidBackGestureProgress(
+            x: 100.0,
+            y: 300.0,
+            progress: 0.3,
+          );
+          await tester.pump();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+            reason:
+                'With the default transition builder, '
+                'predictive back gesture should not affect the size.',
+          );
+
+          await tester.updateAndroidBackGestureProgress(
+            x: 200.0,
+            y: 300.0,
+            progress: 0.6,
+          );
+          await tester.pump();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+          );
+
+          final sizeHistory = <Size>[];
+
+          await tester.commitAndroidBackGesture();
+          await tester.pump();
+          sizeHistory.add(tester.getRect(find.byType(NavigatorResizable)).size);
+          await tester.pump(const Duration(milliseconds: 50));
+          sizeHistory.add(tester.getRect(find.byType(NavigatorResizable)).size);
+          await tester.pump(const Duration(milliseconds: 50));
+          sizeHistory.add(tester.getRect(find.byType(NavigatorResizable)).size);
+          await tester.pump(const Duration(milliseconds: 50));
+          sizeHistory.add(tester.getRect(find.byType(NavigatorResizable)).size);
+          await tester.pump(const Duration(milliseconds: 50));
+          sizeHistory.add(tester.getRect(find.byType(NavigatorResizable)).size);
+          await tester.pumpAndSettle();
+          sizeHistory.add(tester.getRect(find.byType(NavigatorResizable)).size);
+
+          expect(sizeHistory.first, const Size(200, 300));
+          expect(sizeHistory.last, const Size(100, 200));
+          expect(
+            sizeHistory.map((s) => s.width),
+            isMonotonicallyDecreasing,
+            reason:
+                'After committing the back gesture, the size should animate to '
+                'the target size just like a normal pop transition.',
+          );
+          expect(sizeHistory.map((s) => s.height), isMonotonicallyDecreasing);
+        },
+      );
+
+      testWidgets(
+        'When back gesture is canceled',
+        variant: TargetPlatformVariant.only(TargetPlatform.android),
+        (tester) async {
+          final env = boilerplate();
+          await tester.pumpWidget(env.testWidget);
+
+          unawaited(env.navigatorKey.currentState!.pushNamed('b'));
+          await tester.pumpAndSettle();
+
+          await tester.startAndroidBackGesture(
+            touchOffset: [5.0, 300.0],
+          );
+          await tester.pump();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+          );
+
+          await tester.updateAndroidBackGestureProgress(
+            x: 100.0,
+            y: 300.0,
+            progress: 0.3,
+          );
+          await tester.pump();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+          );
+
+          await tester.cancelAndroidBackGesture();
+          await tester.pump();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+          );
+
+          await tester.pump(const Duration(milliseconds: 100));
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+            reason:
+                'The size is already at the target size, '
+                'no size animation should occur.',
+          );
+
+          await tester.pumpAndSettle();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+          );
+        },
+      );
+    },
+  );
 
   group('Size transition test with declarative navigator API', () {
     ({
@@ -859,6 +1031,194 @@ void main() {
       },
     );
   });
+
+  group(
+    'Android predictive back gesture test with '
+    'declarative navigator API and ResizableMaterialPage',
+    () {
+      ({
+        GlobalKey<NavigatorState> navigatorKey,
+        ValueSetter<String> setLocation,
+        Widget testWidget,
+      })
+      boilerplate() {
+        final navigatorKey = GlobalKey<NavigatorState>();
+        final navigatorResizableKey = UniqueKey();
+        const pageA = ResizableMaterialPage(
+          name: 'a',
+          key: ValueKey('a'),
+          child: _TestRouteWidget(initialSize: Size(100, 200)),
+        );
+        const pageB = ResizableMaterialPage(
+          name: 'b',
+          key: ValueKey('b'),
+          child: _TestRouteWidget(initialSize: Size(200, 300)),
+        );
+
+        var location = '/a';
+        late StateSetter setStateFn;
+        void setLocation(String newLocation) {
+          location = newLocation;
+          setStateFn(() {});
+        }
+
+        final testWidget = MaterialApp(
+          home: Center(
+            child: NavigatorResizable(
+              key: navigatorResizableKey,
+              child: StatefulBuilder(
+                builder: (_, setState) {
+                  setStateFn = setState;
+                  return Navigator(
+                    key: navigatorKey,
+                    onDidRemovePage: (page) {},
+                    pages: switch (location) {
+                      '/a' => [pageA],
+                      '/a/b' => [pageA, pageB],
+                      _ => throw StateError('Unknown location: $location'),
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        return (
+          navigatorKey: navigatorKey,
+          setLocation: setLocation,
+          testWidget: testWidget,
+        );
+      }
+
+      testWidgets(
+        'When back gesture is performed',
+        variant: TargetPlatformVariant.only(TargetPlatform.android),
+        (tester) async {
+          final env = boilerplate();
+          await tester.pumpWidget(env.testWidget);
+
+          env.setLocation('/a/b');
+          await tester.pumpAndSettle();
+
+          await tester.startAndroidBackGesture(
+            touchOffset: [5.0, 300.0],
+          );
+          await tester.pump();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+          );
+
+          await tester.updateAndroidBackGestureProgress(
+            x: 100.0,
+            y: 300.0,
+            progress: 0.3,
+          );
+          await tester.pump();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+            reason:
+                'With the default transition builder, '
+                'predictive back gesture should not affect the size.',
+          );
+
+          await tester.updateAndroidBackGestureProgress(
+            x: 200.0,
+            y: 300.0,
+            progress: 0.6,
+          );
+          await tester.pump();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+          );
+
+          final sizeHistory = <Size>[];
+
+          await tester.commitAndroidBackGesture();
+          await tester.pump();
+          sizeHistory.add(tester.getRect(find.byType(NavigatorResizable)).size);
+          await tester.pump(const Duration(milliseconds: 50));
+          sizeHistory.add(tester.getRect(find.byType(NavigatorResizable)).size);
+          await tester.pump(const Duration(milliseconds: 50));
+          sizeHistory.add(tester.getRect(find.byType(NavigatorResizable)).size);
+          await tester.pump(const Duration(milliseconds: 50));
+          sizeHistory.add(tester.getRect(find.byType(NavigatorResizable)).size);
+          await tester.pump(const Duration(milliseconds: 50));
+          sizeHistory.add(tester.getRect(find.byType(NavigatorResizable)).size);
+          await tester.pumpAndSettle();
+          sizeHistory.add(tester.getRect(find.byType(NavigatorResizable)).size);
+
+          expect(sizeHistory.first, const Size(200, 300));
+          expect(sizeHistory.last, const Size(100, 200));
+          expect(
+            sizeHistory.map((s) => s.width),
+            isMonotonicallyDecreasing,
+            reason:
+                'After committing the back gesture, the size should animate to '
+                'the target size just like a normal pop transition.',
+          );
+          expect(sizeHistory.map((s) => s.height), isMonotonicallyDecreasing);
+        },
+      );
+
+      testWidgets(
+        'When back gesture is canceled',
+        variant: TargetPlatformVariant.only(TargetPlatform.android),
+        (tester) async {
+          final env = boilerplate();
+          await tester.pumpWidget(env.testWidget);
+
+          env.setLocation('/a/b');
+          await tester.pumpAndSettle();
+
+          await tester.startAndroidBackGesture(
+            touchOffset: [5.0, 300.0],
+          );
+          await tester.pump();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+          );
+
+          await tester.updateAndroidBackGestureProgress(
+            x: 100.0,
+            y: 300.0,
+            progress: 0.3,
+          );
+          await tester.pump();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+          );
+
+          await tester.cancelAndroidBackGesture();
+          await tester.pump();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+          );
+
+          await tester.pump(const Duration(milliseconds: 100));
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+            reason:
+                'The size is already at the target size, '
+                'no size animation should occur.',
+          );
+
+          await tester.pumpAndSettle();
+          expect(
+            tester.getRect(find.byType(NavigatorResizable)).size,
+            const Size(200, 300),
+          );
+        },
+      );
+    },
+  );
 
   group('Layout test', () {
     ({


### PR DESCRIPTION
Works around for an issue where `TransitionRoute.animation` jumps from a mid-transition value to `1.0` when the back gesture is committed, causing an abrupt pop-transition animation.

The root cause is that `TransitionRoute.handleUpdateBackGestureProgress` updates the `TransitionRoute.controller`'s value as the gesture progresses, but `TransitionRoute.handleCommitBackGesture` triggers the transition animation via `AnimationController.reverse` with `1.0` as the starting point, regardless of the current `TransitionRoute.controller`'s value.

The default back gesture handler behaves this way, but is incompatible with `NavigatorResizable`'s size transition. This PR therefore suppresses gesture-driven transition progress while still allowing the gesture to commit a route pop.

Note that this change affects only `ResizableMaterialPageRoute` and `ResizableMaterialPage`. Developers can still create custom routes and pages that support a back-gesture-driven transition by using `ResizablePageRouteBuilder` or by creating their own route with `ObservableRouteMixin`, at their own responsibility.