### PR TITLE
Fix assertion errors when the page stack changes mid-transition

### DIFF
--- a/lib/src/navigator_event_observer.dart
+++ b/lib/src/navigator_event_observer.dart
@@ -282,15 +282,28 @@ class NavigatorEventObserverState extends State<NavigatorEventObserver> {
       return;
     }
 
-    assert(route.isCurrent);
+    if (!route.isCurrent) {
+      // The navigation stack was changed in a way that removed the
+      // `poppedRoute` without making the `route` the top-most one, e.g. when
+      // several routes are removed at once through the Pages API. Whichever
+      // route did become current reports its own push or pop, so there is no
+      // transition for us to start here.
+      return;
+    }
+
     if (poppedRoute is! TransitionRoute<dynamic> ||
-        poppedRoute.animation!.status == AnimationStatus.dismissed) {
+        poppedRoute.animation!.status != AnimationStatus.reverse) {
+      // Either the popped route has no transition animation at all, or it was
+      // removed without running one. The latter happens when the page stack
+      // shrinks while another transition is still in flight: the route is
+      // detached outright, so its animation never leaves the state it was in
+      // (typically `completed`). Both cases are instantaneous, so the `route`
+      // is settled right away.
       _lastSettledRoute = route;
       _notifyListeners((it) => it.didEndTransition(route));
       return;
     }
 
-    assert(poppedRoute.animation!.status == AnimationStatus.reverse);
     _notifyListeners((it) {
       it.didStartTransition(
         route,

--- a/test/declarative_multi_pop_test.dart
+++ b/test/declarative_multi_pop_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:navigator_resizable/src/navigator_resizable.dart';
+import 'package:navigator_resizable/src/resizable_navigator_routes.dart';
+
+/// Regression tests for the assertion errors that occur when the page stack is
+/// changed faster than the route transitions can settle.
+///
+/// With the Pages API a single `setState` can remove several routes at once,
+/// and it can do so while a push transition is still running. In both cases
+/// `Route.didChangeNext(null)` is reported for a route that is neither the new
+/// top-most route, nor has a next route whose transition is running in reverse.
+void main() {
+  const pageA = ResizableMaterialPage(
+    key: ValueKey('a'),
+    child: SizedBox(width: 280, height: 160),
+  );
+  const pageB = ResizableMaterialPage(
+    key: ValueKey('b'),
+    child: SizedBox(width: 320, height: 220),
+  );
+  const pageC = ResizableMaterialPage(
+    key: ValueKey('c'),
+    child: SizedBox(width: 360, height: 280),
+  );
+  const pageD = ResizableMaterialPage(
+    key: ValueKey('d'),
+    child: SizedBox(width: 300, height: 200),
+  );
+
+  Widget buildApp(List<Page<dynamic>> pages) {
+    return MaterialApp(
+      home: Center(
+        child: NavigatorResizable(
+          child: Navigator(pages: pages, onDidRemovePage: (_) {}),
+        ),
+      ),
+    );
+  }
+
+  /// Walks through [stacks], leaving [settleDuration] between each change so
+  /// that the transitions are still running when the next change arrives.
+  Future<void> walk(
+    WidgetTester tester,
+    List<List<Page<dynamic>>> stacks, {
+    Duration settleDuration = const Duration(milliseconds: 40),
+  }) async {
+    for (final stack in stacks) {
+      await tester.pumpWidget(buildApp(stack));
+      await tester.pump(settleDuration);
+    }
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('Popping two routes in the middle of a push transition', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildApp([pageA, pageB]));
+    await tester.pumpAndSettle();
+
+    await walk(tester, [
+      [pageA, pageB, pageC],
+      [pageA],
+    ]);
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('Reverting a push in the middle of its transition', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildApp([pageA, pageB]));
+    await tester.pumpAndSettle();
+
+    await walk(tester, [
+      [pageA, pageB, pageC],
+      [pageA, pageB],
+    ]);
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('Popping routes one after another without settling', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildApp([pageA, pageB, pageC]));
+    await tester.pumpAndSettle();
+
+    await walk(tester, [
+      [pageA, pageB],
+      [pageA],
+    ]);
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('Replacing the whole stack in the middle of a transition', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildApp([pageA]));
+    await tester.pumpAndSettle();
+
+    await walk(tester, [
+      [pageA, pageB, pageC],
+      [pageD],
+      [pageA, pageB],
+      [pageA],
+    ]);
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('Route stack changes still resize the navigator', (tester) async {
+    await tester.pumpWidget(buildApp([pageA]));
+    await tester.pumpAndSettle();
+    final box = tester.renderObject<RenderBox>(
+      find.byType(NavigatorResizable),
+    );
+    expect(box.size, const Size(280, 160));
+
+    await walk(tester, [
+      [pageA, pageB, pageC],
+      [pageA],
+    ]);
+    expect(
+      box.size,
+      const Size(280, 160),
+      reason: 'Back at page A, the navigator must be sized to A again.',
+    );
+
+    await walk(tester, [
+      [pageD],
+    ]);
+    expect(box.size, const Size(300, 200));
+  });
+}


### PR DESCRIPTION
## Problem

`NavigatorEventObserver` throws in debug builds when the page stack is changed faster than the route transitions can settle.

Reproduced with `example/lib/minimal_declarative_example.dart` by tapping the destination buttons in quick succession:

```
'package:navigator_resizable/src/navigator_event_observer.dart':
Failed assertion: line 285 pos 12: 'route.isCurrent': is not true.
```

Once it throws, `NavigatorState._debugLocked` is left set, so every subsequent navigation throws `'!_debugLocked': is not true` and the nested navigator stays broken for the rest of the session.

## Root cause

Both assertions in `_didPopNextInternal` describe a single, settled pop. The Pages API does not guarantee either property: one `setState` can remove several routes at once, and it can do so while a push transition is still running.

Instrumenting `[a, b, c] -> [a]` while `c`'s push transition is still running:

```
_didChangeNext route=a next=null prevNext=b didPopNext=true routeIsCurrent=true
  _didPopNextInternal route=a popped=b poppedStatus=completed poppedIsActive=false
```

`b` was detached outright rather than transitioned out, so its animation never left `completed` and `assert(poppedRoute.animation!.status == AnimationStatus.reverse)` fails.

`assert(route.isCurrent)` fails for the same underlying reason: when more than one route is removed at once, the route whose `next` became `null` is not the one that ended up on top.

## Fix

Both assertions are replaced with the handling those situations call for.

- **The route did not become current.** There is no transition to start here, because whichever route did become current reports its own push or pop. Return early.
- **The popped route is not running a reverse transition.** The removal is instantaneous, which is exactly the case the existing `dismissed` branch already handles, so that branch is widened from `== dismissed` to `!= reverse`.

## Verification

Swept every ordered triple of the four destinations in `minimal_declarative_example.dart` at five inter-tap delays (0/16/40/100/200 ms, 320 sequences), checking both that nothing is thrown and that the navigator settles at the size of the top-most page:

|  | before | after |
| --- | --- | --- |
| sequences throwing | 24 | 0 |
| sequences settling at the wrong size | not measured (the throwing sequences abort first) | 0 of 320 |

The existing suite (77 tests) is untouched and green.

`test/declarative_multi_pop_test.dart` adds 5 regression tests for the patterns involved; 2 of them fail on `main`.

Tested against Flutter 3.44.9.

## Note

This addresses the failure modes, not the underlying approach. Inferring navigation state from lifecycle callbacks stays sensitive to the stack changes the Pages API permits, and #16 and the `Navigator.replace` fix in 3.0.1 belong to the same family. Happy to discuss a more structural direction separately if that is of interest.
