### PR TITLE
Bump minimum Flutter SDK version to 3.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.0.4-wip
 
 - Fix: assertion error when popping multiple routes in the middle of a push transition
+- Bump minimum Flutter SDK version to 3.41.0
 
 ## 3.0.3
 

--- a/example/lib/complex_go_router_example.dart
+++ b/example/lib/complex_go_router_example.dart
@@ -18,10 +18,8 @@ final _router = GoRouter(
       builder: (context, state) => const Home(),
       routes: [
         ShellRoute(
-          pageBuilder: (context, state, child) => MultiPageDialogPage(
-            key: state.pageKey,
-            navigator: child,
-          ),
+          pageBuilder: (context, state, child) =>
+              MultiPageDialogPage(key: state.pageKey, navigator: child),
           routes: [
             GoRoute(
               path: 'a',
@@ -59,32 +57,32 @@ final _router = GoRouter(
                           path: 'd',
                           pageBuilder: (context, state) =>
                               ResizableMaterialPage(
-                            key: state.pageKey,
-                            child: FormPage(
-                              autoFocus: true,
-                              submitButton: FilledButton(
-                                onPressed: () => context.go('/a/b/c/d/e'),
-                                child: Text('Next'),
+                                key: state.pageKey,
+                                child: FormPage(
+                                  autoFocus: true,
+                                  submitButton: FilledButton(
+                                    onPressed: () => context.go('/a/b/c/d/e'),
+                                    child: Text('Next'),
+                                  ),
+                                ),
                               ),
-                            ),
-                          ),
                           routes: [
                             GoRoute(
                               path: 'e',
                               pageBuilder: (context, state) =>
                                   ResizableMaterialPage(
-                                key: state.pageKey,
-                                child: PortalPage(
-                                  destinations: [
-                                    '/a/b/c/d',
-                                    '/a/b/c',
-                                    '/a/b',
-                                    '/a',
-                                  ],
-                                  onGoToDestination: (destination) =>
-                                      context.go(destination),
-                                ),
-                              ),
+                                    key: state.pageKey,
+                                    child: PortalPage(
+                                      destinations: [
+                                        '/a/b/c/d',
+                                        '/a/b/c',
+                                        '/a/b',
+                                        '/a',
+                                      ],
+                                      onGoToDestination: (destination) =>
+                                          context.go(destination),
+                                    ),
+                                  ),
                             ),
                           ],
                         ),
@@ -99,12 +97,7 @@ final _router = GoRouter(
               pageBuilder: (context, state) => ResizableMaterialPage(
                 key: state.pageKey,
                 child: PortalPage(
-                  destinations: [
-                    '/a/b/c/d',
-                    '/a/b/c',
-                    '/a/b',
-                    '/a',
-                  ],
+                  destinations: ['/a/b/c/d', '/a/b/c', '/a/b', '/a'],
                   onGoToDestination: (destination) => context.go(destination),
                 ),
               ),
@@ -137,10 +130,7 @@ class Home extends StatelessWidget {
 /// Because the SDK does not provide [Page] for dialog widgets,
 /// we need to define one ourselves.
 class MultiPageDialogPage extends Page {
-  const MultiPageDialogPage({
-    super.key,
-    required this.navigator,
-  });
+  const MultiPageDialogPage({super.key, required this.navigator});
 
   final Widget navigator;
 
@@ -151,9 +141,8 @@ class MultiPageDialogPage extends Page {
 }
 
 class PageBasedMultiPageDialogRoute extends PageRoute<void> {
-  PageBasedMultiPageDialogRoute({
-    required MultiPageDialogPage page,
-  }) : super(settings: page);
+  PageBasedMultiPageDialogRoute({required MultiPageDialogPage page})
+    : super(settings: page);
 
   MultiPageDialogPage get page => settings as MultiPageDialogPage;
 
@@ -184,9 +173,7 @@ class PageBasedMultiPageDialogRoute extends PageRoute<void> {
     Animation<double> animation,
     Animation<double> secondaryAnimation,
   ) {
-    return MultiPageDialog(
-      navigator: page.navigator,
-    );
+    return MultiPageDialog(navigator: page.navigator);
   }
 
   @override
@@ -196,9 +183,6 @@ class PageBasedMultiPageDialogRoute extends PageRoute<void> {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    return FadeTransition(
-      opacity: animation,
-      child: child,
-    );
+    return FadeTransition(opacity: animation, child: child);
   }
 }

--- a/example/lib/complex_imperative_example.dart
+++ b/example/lib/complex_imperative_example.dart
@@ -51,9 +51,8 @@ void pushVariableHeightPage(BuildContext context) {
   Navigator.push(
     context,
     ResizableMaterialPageRoute(
-      builder: (context) => VariableHeightPage(
-        onNext: () => pushFormPage(context),
-      ),
+      builder: (context) =>
+          VariableHeightPage(onNext: () => pushFormPage(context)),
     ),
   );
 }

--- a/example/lib/minimal_declarative_example.dart
+++ b/example/lib/minimal_declarative_example.dart
@@ -153,10 +153,7 @@ class _ExampleRouteContent extends StatelessWidget {
         color: color,
         borderRadius: BorderRadius.circular(8),
       ),
-      child: Text(
-        title,
-        style: Theme.of(context).textTheme.displayMedium,
-      ),
+      child: Text(title, style: Theme.of(context).textTheme.displayMedium),
     );
   }
 }

--- a/example/lib/src/multi_page_dialog.dart
+++ b/example/lib/src/multi_page_dialog.dart
@@ -4,10 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:navigator_resizable/navigator_resizable.dart';
 
 class MultiPageDialog extends StatelessWidget {
-  const MultiPageDialog({
-    super.key,
-    required this.navigator,
-  });
+  const MultiPageDialog({super.key, required this.navigator});
 
   final Widget navigator;
 
@@ -27,9 +24,7 @@ class MultiPageDialog extends StatelessWidget {
         child: Material(
           borderRadius: BorderRadius.circular(12),
           clipBehavior: Clip.antiAlias,
-          child: NavigatorResizable(
-            child: navigator,
-          ),
+          child: NavigatorResizable(child: navigator),
         ),
       ),
     );

--- a/example/lib/src/variable_height_page.dart
+++ b/example/lib/src/variable_height_page.dart
@@ -4,10 +4,7 @@ import 'package:example/src/dialog_content_layout.dart';
 import 'package:flutter/material.dart';
 
 class VariableHeightPage extends StatefulWidget {
-  const VariableHeightPage({
-    super.key,
-    required this.onNext,
-  });
+  const VariableHeightPage({super.key, required this.onNext});
 
   final VoidCallback onNext;
 
@@ -38,9 +35,7 @@ class _VariableHeightPageState extends State<VariableHeightPage> {
             ),
           ),
         ),
-        const Divider(
-          height: 24,
-        ),
+        const Divider(height: 24),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
@@ -54,10 +49,7 @@ class _VariableHeightPageState extends State<VariableHeightPage> {
               icon: Icon(Icons.remove),
             ),
             const Spacer(),
-            FilledButton(
-              onPressed: widget.onNext,
-              child: Text('Next'),
-            ),
+            FilledButton(onPressed: widget.onNext, child: Text('Next')),
           ],
         ),
       ],

--- a/example/lib/src/welcome_page.dart
+++ b/example/lib/src/welcome_page.dart
@@ -19,9 +19,7 @@ class WelcomePage extends StatelessWidget {
       children: [
         FilledButton(
           onPressed: onNext,
-          style: FilledButton.styleFrom(
-            minimumSize: Size(double.infinity, 48),
-          ),
+          style: FilledButton.styleFrom(minimumSize: Size(double.infinity, 48)),
           child: const Text('Next'),
         ),
         const SizedBox(height: 12),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: "none"
 version: 0.1.0
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.27.0"
+  sdk: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ topics:
   - navigation
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.1"
+  sdk: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Raises the minimum Flutter SDK version to 3.41.0 to avoid a mid-transition issue which is rooted in the framework:

> Fixes crash when adding and removing mulitple page-based route by @chunhtai in 177338

See https://docs.flutter.dev/release/release-notes/release-notes-3.41.0 for more details.
